### PR TITLE
trigger 'in_view' event for slates being engaged

### DIFF
--- a/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/SlateSessionStateCode.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/SlateSessionStateCode.php
@@ -26,7 +26,10 @@ trait SlateSessionStateCode
      */
     public function addOnloadCode(Slate $slate, isItem $item) : Slate
     {
-        $signal = $slate->getEngageSignal();
+
+        $signal_generator = new \ILIAS\UI\Implementation\Component\SignalGenerator();
+        $signal = $signal_generator->create();
+        $slate = $slate->appendOnEngage($signal);
 
         $identification = $item->getProviderIdentification()->serialize();
 

--- a/src/UI/Implementation/Component/MainControls/Slate/Slate.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Slate.php
@@ -148,6 +148,6 @@ abstract class Slate implements ISlate\Slate
      */
     public function appendOnEngage(Signal $signal) : \ILIAS\UI\Component\MainControls\Slate\Slate
     {
-        return $this->appendTriggeredSignal($signal, $this->getEngageSignal()->getId());
+        return $this->appendTriggeredSignal($signal, 'in_view');
     }
 }

--- a/src/UI/templates/js/MainControls/slate.js
+++ b/src/UI/templates/js/MainControls/slate.js
@@ -65,6 +65,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			slate.addClass(_cls_engaged);
 			slate.attr("aria-expanded", "true");
 			slate.attr("aria-hidden", "false");
+			slate.trigger('in_view');
 		};
 
 		var disengage = function(slate) {


### PR DESCRIPTION
Hey @chfsx ,
this will trigger the (brutally summoned) signal from addOnloadCode whenever a slate comes into the user's view.
I think this is what you wanted, right?
Cheers, 
Nils