### PR TITLE
[FIX] use Streams for Certificate-ZIP

### DIFF
--- a/Services/Certificate/classes/Helper/ilCertificateUtilHelper.php
+++ b/Services/Certificate/classes/Helper/ilCertificateUtilHelper.php
@@ -83,13 +83,6 @@ class ilCertificateUtilHelper
         );
     }
 
-    public function deliverFile(string $zipPath, string $zipFileName, string $mime): void
-    {
-        $this->delivery->delivery()->
-
-        ilFileDelivery::deliverFileLegacy($zipPath, $zipFileName, $mime);
-    }
-
     public function getDir(string $copyDirectory): array
     {
         return ilFileUtils::getDir($copyDirectory);

--- a/Services/Certificate/test/ilCertificateBackgroundImageUploadTest.php
+++ b/Services/Certificate/test/ilCertificateBackgroundImageUploadTest.php
@@ -76,6 +76,7 @@ class ilCertificateBackgroundImageUploadTest extends ilCertificateBaseTestCase
             ->method('delete');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->expects($this->exactly(2))
@@ -158,6 +159,7 @@ class ilCertificateBackgroundImageUploadTest extends ilCertificateBaseTestCase
             ->method('writeStream');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->expects($this->exactly(2))

--- a/Services/Certificate/test/ilCertificateLearningHistoryProviderTest.php
+++ b/Services/Certificate/test/ilCertificateLearningHistoryProviderTest.php
@@ -61,6 +61,10 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
         $provider = new ilCertificateLearningHistoryProvider(
             10,
             $learningHistoryFactory,
@@ -71,7 +75,8 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
             $controller,
             $certificateSettings,
             $uiFactory,
-            $uiRenderer
+            $uiRenderer,
+            $utilHelper
         );
 
         $this->assertTrue($provider->isActive());
@@ -304,6 +309,10 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
         $provider = new ilCertificateLearningHistoryProvider(
             10,
             $learningHistoryFactory,
@@ -314,7 +323,8 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
             $controller,
             $certificateSettings,
             $uiFactory,
-            $uiRenderer
+            $uiRenderer,
+            $utilHelper
         );
 
         $this->assertSame('Certificates', $provider->getName());

--- a/Services/Certificate/test/ilCertificatePdfActionTest.php
+++ b/Services/Certificate/test/ilCertificatePdfActionTest.php
@@ -34,6 +34,7 @@ class ilCertificatePdfActionTest extends ilCertificateBaseTestCase
             ->willReturn('Something');
 
         $ilUtilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $errorHandler = $this->getMockBuilder(ilErrorHandling::class)
@@ -66,6 +67,7 @@ class ilCertificatePdfActionTest extends ilCertificateBaseTestCase
             ->willReturn('some_file_name.pdf');
 
         $ilUtilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $ilUtilHelper->method('deliverData')
@@ -104,6 +106,7 @@ class ilCertificatePdfActionTest extends ilCertificateBaseTestCase
             ->willReturn('some_file_name.pdf');
 
         $ilUtilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $ilUtilHelper->method('deliverData')

--- a/Services/Certificate/test/ilCertificateTemplateDeleteActionTest.php
+++ b/Services/Certificate/test/ilCertificateTemplateDeleteActionTest.php
@@ -47,6 +47,7 @@ class ilCertificateTemplateDeleteActionTest extends ilCertificateBaseTestCase
             ));
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper
@@ -100,6 +101,7 @@ class ilCertificateTemplateDeleteActionTest extends ilCertificateBaseTestCase
             ));
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper

--- a/Services/Certificate/test/ilCertificateTemplateExportActionTest.php
+++ b/Services/Certificate/test/ilCertificateTemplateExportActionTest.php
@@ -44,23 +44,8 @@ class ilCertificateTemplateExportActionTest extends ilCertificateBaseTestCase
             ));
 
         $filesystem = $this->getMockBuilder(ILIAS\Filesystem\Filesystem::class)
+            ->disableOriginalConstructor()
             ->getMock();
-
-        $filesystem
-            ->expects($this->once())
-            ->method('createDir');
-
-        $filesystem
-            ->expects($this->once())
-            ->method('put');
-
-        $filesystem
-            ->expects($this->once())
-            ->method('deleteDir');
-
-        $filesystem
-            ->expects($this->once())
-            ->method('put');
 
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();
@@ -69,15 +54,12 @@ class ilCertificateTemplateExportActionTest extends ilCertificateBaseTestCase
             ->willReturn('crs');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper
             ->expects($this->once())
             ->method('zipAndDeliver');
-
-        $utilHelper
-            ->expects($this->once())
-            ->method('deliverFile');
 
         $action = new ilCertificateTemplateExportAction(
             100,

--- a/Services/Certificate/test/ilCertificateTemplateImportActionTest.php
+++ b/Services/Certificate/test/ilCertificateTemplateImportActionTest.php
@@ -48,6 +48,7 @@ class ilCertificateTemplateImportActionTest extends ilCertificateBaseTestCase
             ->willReturn('crs');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper
@@ -128,6 +129,7 @@ class ilCertificateTemplateImportActionTest extends ilCertificateBaseTestCase
             ->willReturn('crs');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper
@@ -197,6 +199,7 @@ class ilCertificateTemplateImportActionTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper
@@ -262,6 +265,7 @@ class ilCertificateTemplateImportActionTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper

--- a/Services/Certificate/test/ilCertificateTemplatePreviewActionTest.php
+++ b/Services/Certificate/test/ilCertificateTemplatePreviewActionTest.php
@@ -54,6 +54,7 @@ class ilCertificateTemplatePreviewActionTest extends ilCertificateBaseTestCase
             ->willReturn(100);
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper

--- a/Services/Certificate/test/ilCoursePlaceholderValuesTest.php
+++ b/Services/Certificate/test/ilCoursePlaceholderValuesTest.php
@@ -66,6 +66,7 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('2018-09-10');
 
         $ilUtilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $ilUtilHelper->method('prepareFormOutput')
@@ -152,6 +153,7 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')

--- a/Services/Certificate/test/ilDefaultPlaceholderValuesTest.php
+++ b/Services/Certificate/test/ilDefaultPlaceholderValuesTest.php
@@ -130,6 +130,7 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('Something');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')
@@ -206,6 +207,7 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('Something');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')

--- a/Services/Certificate/test/ilExercisePlaceHolderValuesTest.php
+++ b/Services/Certificate/test/ilExercisePlaceHolderValuesTest.php
@@ -69,6 +69,7 @@ class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('aaa');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->expects($this->exactly(2))
@@ -147,6 +148,7 @@ class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')

--- a/Services/Certificate/test/ilScormPlaceholderValuesTest.php
+++ b/Services/Certificate/test/ilScormPlaceholderValuesTest.php
@@ -74,6 +74,7 @@ class ilScormPlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn($objectMock);
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')
@@ -193,6 +194,7 @@ class ilScormPlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn($objectMock);
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')

--- a/Services/Certificate/test/ilTestPlaceHolderValuesTest.php
+++ b/Services/Certificate/test/ilTestPlaceHolderValuesTest.php
@@ -102,6 +102,7 @@ class ilTestPlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('2018-01-12');
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')
@@ -187,6 +188,7 @@ class ilTestPlaceholderValuesTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')

--- a/Services/Certificate/test/ilXlsFoParserTest.php
+++ b/Services/Certificate/test/ilXlsFoParserTest.php
@@ -38,6 +38,7 @@ class ilXlsFoParserTest extends ilCertificateBaseTestCase
         $page_formats = new ilPageFormats($language);
 
         $util_helper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                            ->disableOriginalConstructor()
                             ->getMock();
 
         $util_helper->method('stripSlashes')
@@ -114,6 +115,7 @@ class ilXlsFoParserTest extends ilCertificateBaseTestCase
         $xmlChecker = new ilXMLChecker(new ILIAS\Data\Factory());
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                           ->disableOriginalConstructor()
                            ->getMock();
 
         $utilHelper->method('stripSlashes')
@@ -208,6 +210,7 @@ class ilXlsFoParserTest extends ilCertificateBaseTestCase
         $xmlChecker = new ilXMLChecker(new ILIAS\Data\Factory());
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                           ->disableOriginalConstructor()
                            ->getMock();
 
         $xlstProcess = $this->getMockBuilder(ilCertificateXlstProcess::class)
@@ -279,6 +282,7 @@ class ilXlsFoParserTest extends ilCertificateBaseTestCase
         $xmlChecker = new ilXMLChecker(new ILIAS\Data\Factory());
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                           ->disableOriginalConstructor()
                            ->getMock();
 
         $utilHelper->method('stripSlashes')
@@ -373,6 +377,7 @@ class ilXlsFoParserTest extends ilCertificateBaseTestCase
         $xmlChecker = new ilXMLChecker(new ILIAS\Data\Factory());
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+                           ->disableOriginalConstructor()
                            ->getMock();
 
         $utilHelper->method('stripSlashes')


### PR DESCRIPTION
This PR fixes the failing `Services/Certificates` tests after migrating the export zip process.